### PR TITLE
added another replace function to remove whitespace between words and non words

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gql-compress
+query{repository(owner:\"octocat\",name:\"Hello-World\"){issues(last:20,states:CLOSED){edges{node{title url labels(first:5){edges{node{name}}}}}}}}# gql-compress
 
 Shrink your GraphQL
 
@@ -37,8 +37,8 @@ const uncompressed = `
   }
 ` // 357 bytes
 
-const compressed = compress(uncompressed) // 175 bytes
-// outputs: "query { repository(owner:\"octocat\", name:\"Hello-World\") { issues(last:20, states:CLOSED) { edges { node { title url labels(first:5) { edges { node { name } } } } } } } }"
+const compressed = compress(uncompressed) // 147 bytes
+// outputs: "query{repository(owner:\"octocat\",name:\"Hello-World\"){issues(last:20,states:CLOSED){edges{node{title url labels(first:5){edges{node{name}}}}}}}}"
 ```
 
 Example from [GitHub](https://developer.github.com/v4/guides/forming-calls/).

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,9 @@
 // @flow
 
 export default (s: string = ''): string =>
-  s.replace(/(\b|\B)\s{1,}(\b|\B)/gm, ' ').trim()
+  s
+    // replace multiple whitespace with a single
+    .replace(/(\b|\B)\s{1,}(\b|\B)/gm, ' ')
+    // remove all whitespace between everything except for word and word boundaries
+    .replace(/(\B)\s{1,}(\B)|(\b)\s{1,}(\B)|(\B)\s{1,}(\b)/gm, '')
+    .trim()

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -28,7 +28,8 @@ describe('compress', (): void => {
   }
 `)
     const expected =
-      'query { repository(owner:"octocat", name:"Hello-World") { issues(last:20, states:CLOSED) { edges { node { title url labels(first:5) { edges { node { name } } } } } } } }'
+      // eslint-disable-next-line no-useless-escape
+      'query{repository(owner:"octocat",name:"Hello-World"){issues(last:20,states:CLOSED){edges{node{title url labels(first:5){edges{node{name}}}}}}}}'
     expect(compress(query)).toBe(expected)
   })
 


### PR DESCRIPTION
changes things like `word } } }` to `word}}}` but leaves things like `word another` alone

im not sure if another replace is worth the savings. i couldn't find a regex to do it all in one